### PR TITLE
Re-add "Medium" affordance to Ice terrain

### DIFF
--- a/RimIce/Defs/TerrainDefs.xml
+++ b/RimIce/Defs/TerrainDefs.xml
@@ -13,8 +13,10 @@
     <scatterType>SoftGray</scatterType>
     <affordances>
       <li>Light</li>
+      <li>Medium</li>
       <li>Heavy</li>
       <li>Diggable</li>
+      <li>Icefishable</li>
     </affordances>
     <generatedFilth>Filth_Dirt</generatedFilth>
     <fertility>0.00</fertility>


### PR DESCRIPTION
For whatever reason, I suspect by accident, this mod prevented walls (any walls!) being built on ice ... while still allowing for Heavy? Odd.

I also took the liberty of adding the "Icefishable" affordance, which should support the "Fishing" mod by Rainbeau Flambeau.